### PR TITLE
Create custom plugin for import management

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "license": "ISC",
   "devDependencies": {
     "@electron/asar": "^3.2.1",
-    "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
     "@types/node": "^18.11.2",
     "@typescript-eslint/eslint-plugin": "^5.40.1",
     "@typescript-eslint/parser": "^5.40.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,6 @@ lockfileVersion: 5.4
 
 specifiers:
   '@electron/asar': ^3.2.1
-  '@fal-works/esbuild-plugin-global-externals': ^2.1.2
   '@types/node': ^18.11.2
   '@typescript-eslint/eslint-plugin': ^5.40.1
   '@typescript-eslint/parser': ^5.40.1
@@ -18,7 +17,6 @@ specifiers:
 
 devDependencies:
   '@electron/asar': 3.2.1
-  '@fal-works/esbuild-plugin-global-externals': 2.1.2
   '@types/node': 18.11.2
   '@typescript-eslint/eslint-plugin': 5.40.1_ukgdydjtebaxmxfqp5v5ulh64y
   '@typescript-eslint/parser': 5.40.1_z4bbprzjrhnsfa24uvmcbu7f5q
@@ -101,10 +99,6 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@fal-works/esbuild-plugin-global-externals/2.1.2:
-    resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
     dev: true
 
   /@humanwhocodes/config-array/0.10.7:


### PR DESCRIPTION
The primary benefit to this change is that we don't have to maintain a list of properties that can be imported. This also means that users won't have to constantly update that file and can just install the new `replugged` package to get new properties.

In addition, I added a better error message for importing from a path (eg `import { waitForModule } from "replugged/dist/renderer/modules/webpack";`). Still need to figure out how to make intellisense stop suggesting that.